### PR TITLE
Added Proton XBE support, updated Linux kernel headers version to 6.12

### DIFF
--- a/.github/workflows/proton-arch-nopackage.yml
+++ b/.github/workflows/proton-arch-nopackage.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo lib32-jack2
-          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.8/main/include/uapi/linux/ntsync.h
+          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R ..
           chown user -R /tmp

--- a/.github/workflows/proton-arch-nopackage.yml
+++ b/.github/workflows/proton-arch-nopackage.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo lib32-jack2
-          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
+          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/torvalds/linux/13845bdc869f136f92ad3d40ea09b867bb4ce467/include/uapi/linux/ntsync.h
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R ..
           chown user -R /tmp
@@ -25,12 +25,6 @@ jobs:
           sed -i 's/uninstaller="false"/uninstaller="true"/' proton-tkg.cfg
           sed -i 's/autoinstall="false"/autoinstall="true"/' proton-tkg.cfg
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="none"/' proton-tkg.cfg
-          sed -i 's/build_gstreamer="false"/build_gstreamer="true"/' proton-tkg.cfg
-          sed -i 's/lib32_gstreamer="false"/lib32_gstreamer="true"/' proton-tkg.cfg
-          sed -i 's/wayland_driver="false"/wayland_driver="true"/' proton-tkg.cfg
-          sed -i 's/ntsync="false"/ntsync="true"/' proton-tkg.cfg
-          sed -i 's/esync="true"/esync="false"/' proton-tkg.cfg
-          sed -i 's/fsync="true"/fsync="false"/' proton-tkg.cfg
           touch tarplz
           yes|./proton-tkg.sh
       - name: Archive the artifacts

--- a/.github/workflows/proton-valvexbe-arch-nopackage.yml
+++ b/.github/workflows/proton-valvexbe-arch-nopackage.yml
@@ -17,6 +17,7 @@ jobs:
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo lib32-jack2
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
           chown user -R ..
           chown user -R /tmp
           export CARGO_HOME="$PWD"
@@ -26,6 +27,9 @@ jobs:
           sed -i 's/build_gstreamer="false"/build_gstreamer="true"/' proton-tkg.cfg
           sed -i 's/lib32_gstreamer="false"/lib32_gstreamer="true"/' proton-tkg.cfg
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' proton-tkg.cfg
+          sed -i 's/ntsync="false"/ntsync="true"/' proton-tkg.cfg
+          sed -i 's/esync="true"/esync="false"/' proton-tkg.cfg
+          sed -i 's/fsync="true"/fsync="false"/' proton-tkg.cfg
           touch tarplz
           yes|./proton-tkg.sh
       - name: Archive the artifacts

--- a/.github/workflows/proton-valvexbe-arch-nopackage.yml
+++ b/.github/workflows/proton-valvexbe-arch-nopackage.yml
@@ -2,7 +2,7 @@ name: Proton Valve xbe nopackage Arch Linux CI
 
 on:
   schedule:
-    - cron:  '45 8 1 * *'
+    - cron:  '45 8 1,15 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/proton-valvexbe-arch-nopackage.yml
+++ b/.github/workflows/proton-valvexbe-arch-nopackage.yml
@@ -17,19 +17,13 @@ jobs:
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo lib32-jack2
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
+          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/torvalds/linux/13845bdc869f136f92ad3d40ea09b867bb4ce467/include/uapi/linux/ntsync.h
           chown user -R ..
           chown user -R /tmp
           export CARGO_HOME="$PWD"
           cd proton-tkg
           sed -i 's/uninstaller="false"/uninstaller="true"/' proton-tkg.cfg
           sed -i 's/autoinstall="false"/autoinstall="true"/' proton-tkg.cfg
-          sed -i 's/build_gstreamer="false"/build_gstreamer="true"/' proton-tkg.cfg
-          sed -i 's/lib32_gstreamer="false"/lib32_gstreamer="true"/' proton-tkg.cfg
-          sed -i 's/wayland_driver="false"/wayland_driver="true"/' proton-tkg.cfg
-          sed -i 's/ntsync="false"/ntsync="true"/' proton-tkg.cfg
-          sed -i 's/esync="true"/esync="false"/' proton-tkg.cfg
-          sed -i 's/fsync="true"/fsync="false"/' proton-tkg.cfg
           touch tarplz
           yes|./proton-tkg.sh
       - name: Archive the artifacts

--- a/.github/workflows/proton-valvexbe-arch-nopackage.yml
+++ b/.github/workflows/proton-valvexbe-arch-nopackage.yml
@@ -2,7 +2,7 @@ name: Proton Valve xbe nopackage Arch Linux CI
 
 on:
   schedule:
-    - cron:  '45 8,20 * * *'
+    - cron:  '45 8 1 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -4,7 +4,7 @@ name: 'Upstream Sync'
 
 on:
   schedule:
-    - cron:  '0 * * * *'
+    - cron:  '0 8 1 * *'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -4,7 +4,7 @@ name: 'Upstream Sync'
 
 on:
   schedule:
-    - cron:  '0 8 1 * *'
+    - cron:  '0 8 1,15 * *'
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/wine-arch.yml
+++ b/.github/workflows/wine-arch.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo
-          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.8/main/include/uapi/linux/ntsync.h
+          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R . && cd wine-tkg-git
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg

--- a/.github/workflows/wine-arch.yml
+++ b/.github/workflows/wine-arch.yml
@@ -18,13 +18,9 @@ jobs:
         run: |
           echo -e "[multilib]\nInclude = /etc/pacman.d/mirrorlist" >> /etc/pacman.conf
           pacman -Syu --noconfirm base-devel sudo
-          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
+          curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/torvalds/linux/13845bdc869f136f92ad3d40ea09b867bb4ce467/include/uapi/linux/ntsync.h
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R . && cd wine-tkg-git
-          sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
-          sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
-          sed -i 's/esync="true"/esync="false"/' customization.cfg
-          sed -i 's/fsync="true"/fsync="false"/' customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -17,7 +17,7 @@ jobs:
           sudo dnf -y -q upgrade --refresh
           # ntsync.h from kernel-headers may be broken, overwrite it ourselves
           sudo dnf -y install kernel-headers
-          sudo curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.8/main/include/uapi/linux/ntsync.h
+          sudo curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
           cd wine-tkg-git 
           sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
           sed -i 's/esync="true"/esync="false"/' customization.cfg

--- a/.github/workflows/wine-fedora.yml
+++ b/.github/workflows/wine-fedora.yml
@@ -17,11 +17,8 @@ jobs:
           sudo dnf -y -q upgrade --refresh
           # ntsync.h from kernel-headers may be broken, overwrite it ourselves
           sudo dnf -y install kernel-headers
-          sudo curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
+          sudo curl -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/torvalds/linux/13845bdc869f136f92ad3d40ea09b867bb4ce467/include/uapi/linux/ntsync.h
           cd wine-tkg-git 
-          sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
-          sed -i 's/esync="true"/esync="false"/' customization.cfg
-          sed -i 's/fsync="true"/fsync="false"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -17,11 +17,8 @@ jobs:
           sudo dpkg --add-architecture i386 && sudo apt update
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
-          sudo curl --create-dirs -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
+          sudo curl --create-dirs -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/torvalds/linux/13845bdc869f136f92ad3d40ea09b867bb4ce467/include/uapi/linux/ntsync.h
           cd wine-tkg-git 
-          sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
-          sed -i 's/esync="true"/esync="false"/' customization.cfg
-          sed -i 's/fsync="true"/fsync="false"/' customization.cfg
           sed -i 's/_NOLIB32="false"/_NOLIB32="wow64"/' wine-tkg-profiles/advanced-customization.cfg
           echo '_ci_build="true"' >> customization.cfg
           touch tarplz

--- a/.github/workflows/wine-ubuntu.yml
+++ b/.github/workflows/wine-ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
           sudo dpkg --add-architecture i386 && sudo apt update
           sudo apt install aptitude
           sudo aptitude remove -y '?narrow(?installed,?version(deb.sury.org))'
-          sudo curl --create-dirs -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.8/main/include/uapi/linux/ntsync.h
+          sudo curl --create-dirs -o /usr/include/linux/ntsync.h https://raw.githubusercontent.com/zen-kernel/zen-kernel/6.12/main/include/uapi/linux/ntsync.h
           cd wine-tkg-git 
           sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
           sed -i 's/esync="true"/esync="false"/' customization.cfg

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -2,7 +2,7 @@ name: Wine Valve exp bleeding edge Pacman CI
 
 on:
   schedule:
-    - cron:  '45 8 1 * *'
+    - cron:  '45 8 1,15 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -20,6 +20,9 @@ jobs:
           chown user -R . && cd wine-tkg-git
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="valve-exp-bleeding"/' customization.cfg
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
+          sed -i 's/ntsync="false"/ntsync="true"/' proton-tkg.cfg
+          sed -i 's/esync="true"/esync="false"/' proton-tkg.cfg
+          sed -i 's/fsync="true"/fsync="false"/' proton-tkg.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -19,10 +19,6 @@ jobs:
           useradd user -G wheel && echo "user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
           chown user -R . && cd wine-tkg-git
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="valve-exp-bleeding"/' customization.cfg
-          sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
-          sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
-          sed -i 's/esync="true"/esync="false"/' customization.cfg
-          sed -i 's/fsync="true"/fsync="false"/' customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -2,7 +2,7 @@ name: Wine Valve exp bleeding edge Pacman CI
 
 on:
   schedule:
-    - cron:  '45 8,20 * * *'
+    - cron:  '45 8 1 * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wine-valvexbe-pacman.yml
+++ b/.github/workflows/wine-valvexbe-pacman.yml
@@ -20,9 +20,9 @@ jobs:
           chown user -R . && cd wine-tkg-git
           sed -i 's/LOCAL_PRESET=""/LOCAL_PRESET="valve-exp-bleeding"/' customization.cfg
           sed -i 's/wayland_driver="false"/wayland_driver="true"/' customization.cfg
-          sed -i 's/ntsync="false"/ntsync="true"/' proton-tkg.cfg
-          sed -i 's/esync="true"/esync="false"/' proton-tkg.cfg
-          sed -i 's/fsync="true"/fsync="false"/' proton-tkg.cfg
+          sed -i 's/ntsync="false"/ntsync="true"/' customization.cfg
+          sed -i 's/esync="true"/esync="false"/' customization.cfg
+          sed -i 's/fsync="true"/fsync="false"/' customization.cfg
           su user -c "yes|PKGDEST=/tmp/wine-tkg makepkg --noconfirm -s"
 
       - name: Archive the artifacts

--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -84,14 +84,14 @@ _use_fastsync="false"
 # !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
 # !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees !!
-_use_ntsync="false"
+_use_ntsync="true"
 
-_use_esync="true"
-_use_fsync="true"
+_use_esync="false"
+_use_fsync="false"
 
 # Set to true to pass --with-wayland --with-vulkan configure arguments
 # !! Requires a compatible wine tree (9.0+ recommended) !!
-_wayland_driver="false"
+_wayland_driver="true"
 
 _plain_version=""
 _use_staging="true"
@@ -152,10 +152,10 @@ _reuse_built_gst=""
 # Set to "true" to enable building 64-bit patched gstreamer & plugins - This is helpful to support video formats not covered by your distro packages
 # Will build orc, gstreamer, gst-plugins-base, gst-plugins-good, gst-plugins-bad, gst-plugins-ugly, gst-libav
 # _build_mediaconv can be set to false when this is enabled and Steam's shader precaching is disabled
-_build_gstreamer="false"
+_build_gstreamer="true"
 # Set to "true" to also enable building 32-bit patched gstreamer & plugins
 # Depends on _build_gstreamer="true"
-_lib32_gstreamer="false"
+_lib32_gstreamer="true"
 
 # Set to "true" to enable building ffmpeg
 # Depends on _build_gstreamer="true"

--- a/proton-tkg/proton-tkg.cfg
+++ b/proton-tkg/proton-tkg.cfg
@@ -194,3 +194,10 @@ _hotfixes_no_confirm="true"
 _hotfixansw_staging_mfplat=""
 # Set to false to disable staging pulseaudio restoration in case a hotfix is available and _hotfixes_no_confirm is set to "true"
 _hotfixansw_staging_pulse=""
+
+# some random optimizations
+_LOCAL_OPTIMIZED="true"
+_GCC_FLAGS="-O2 -ftree-vectorize -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types"
+_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"
+_CROSS_FLAGS="-O2 -ftree-vectorize -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types"
+_CROSS_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -164,3 +164,10 @@ _community_patches=""
 
 # Automatically update community-patches from git - set to false if you don't want this behaviour, useful for example if you have your own fork.
 _community_patches_auto_update="true"
+
+# some random optimizations
+_LOCAL_OPTIMIZED="true"
+_GCC_FLAGS="-O2 -ftree-vectorize -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types"
+_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"
+_CROSS_FLAGS="-O2 -ftree-vectorize -Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types"
+_CROSS_LD_FLAGS="-Wl,-O1,--sort-common,--as-needed"

--- a/wine-tkg-git/customization.cfg
+++ b/wine-tkg-git/customization.cfg
@@ -70,16 +70,16 @@ _use_fastsync="false"
 # !! (Arch: see the three packages https://aur.archlinux.org/pkgbase/ntsync for both module and header) !!
 # !! Not compatible with _use_esync, _use_fsync or _use_fastsync options !!
 # !! Not compatible with Valve trees !!
-_use_ntsync="false"
+_use_ntsync="true"
 
 # esync - Enable with WINEESYNC=1 envvar - Set to true to enable esync support on plain wine or wine-staging <4.6 (it got merged in wine-staging 4.6). The option is ignored on wine-staging 4.6+
 # You may need to raise your fd limits -> https://github.com/zfigura/wine/blob/esync/README.esync
-_use_esync="true"
+_use_esync="false"
 
 # fsync - Enable with WINEFSYNC=1 envvar - Set to true to enable fsync support on Wine 5.20 and above - Requires kernel 5.16+ or at least linux-tkg 5.13 - https://github.com/ValveSoftware/wine/pull/128
 # !! fsync legacy will be used for Wine 5.19 and lower (Mainline 4.7.r168.g29914d583f / Staging 4.9.r7.g197e08b4) !!
 # !! https://steamcommunity.com/games/221410/announcements/detail/2957094910196249305 !!
-_use_fsync="true"
+_use_fsync="false"
 
 # Set to false to add DXVK configuration support to Wine's DXGI, allowing for VKD3D to run while keeping DXVK dxgi functionalities.
 # !! For DXVK to work properly with this option set to false, you'll need a DXVK build that comes with dxvk_config.dll !!
@@ -88,7 +88,7 @@ _dxvk_dxgi="true"
 
 # Set to true to pass --with-wayland --with-vulkan configure arguments
 # !! Requires a compatible wine tree (9.0+ recommended) !!
-_wayland_driver="false"
+_wayland_driver="true"
 
 
 #### GAME-SPECIFIC PATCHES ####


### PR DESCRIPTION
I tried to use it and found that it couldn't build Proton due to changes in the ntsync patches that made it incompatible with Linux 6.12.
So I updated the headers version to 6.12 and had it build Proton XBE since it didn't work with Deep Rock Galactic on my machine.